### PR TITLE
Edit character extras for Fate Core character sheets. Resolves #31.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,6 +2152,24 @@
         }
       }
     },
+    "@mui/icons-material": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.0.4.tgz",
+      "integrity": "sha512-pW/2bjRGnBZujoLdtH/C+ghT0Tmlk9HmZHF6HuALuVOnRiHF9VwrcNrx0FLHYT0aMARZR4dBA15nU/53R1YNeQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@mui/material": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
+    "@mui/icons-material": "^5.0.4",
     "@mui/material": "^5.0.2",
     "@mui/styles": "^5.0.1",
     "@mui/x-data-grid": "^5.0.0-beta.2",

--- a/src/components/CharacterSheets/FateCoreSheet.js
+++ b/src/components/CharacterSheets/FateCoreSheet.js
@@ -58,10 +58,23 @@ export const FateCoreSheet = ({ rollDice, character, setCharacterData, canEdit,
     saveCharacterData(updatedCharacter);
   }
 
+  const updateTableField = (e, field) => {
+    const cellIndex = e.id
+    const updatedField = character[field].map((element, index) => (
+      index === cellIndex ? {...element, [e.field]: e.value} : element
+    ))
+    const updatedCharacter = {...character, [field]: updatedField}
+    setCharacterData(updatedCharacter)
+  }
+
+  const extrasWithID = extras.map((extra, index) => {
+    return {...extra, id: index}
+  })
+
   const extrasColumns = [
-    {field: 'name', headerName: 'Extra', width: 240},
+    {field: 'name', headerName: 'Extra', width: 240, editable: editActive},
     {field: 'description', headerName: 'Description', width: 240, flex: 1,
-      sortable: false}
+      sortable: false, editable: editActive}
   ]
 
   return (
@@ -153,12 +166,13 @@ export const FateCoreSheet = ({ rollDice, character, setCharacterData, canEdit,
       </dl>
 
       <DataGrid
-        rows={extras}
+        rows={extrasWithID}
         columns={extrasColumns}
-        getRowId={(row) => row.name}
         hideFooter={true}
         autoHeight
+        id='Extras'
         disableSelectionOnClick
+        onCellEditCommit={(e) => updateTableField(e, 'extras')}
       />
     </div>
   );

--- a/src/components/CharacterSheets/FateCoreSheet.js
+++ b/src/components/CharacterSheets/FateCoreSheet.js
@@ -1,6 +1,10 @@
 import { DiceButton } from '../DiceButton';
 import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
 import { DataGrid } from '@mui/x-data-grid';
+import React, { useEffect } from 'react';
 
 const skillLadder = {
   '-2': 'Terrible',
@@ -58,13 +62,31 @@ export const FateCoreSheet = ({ rollDice, character, setCharacterData, canEdit,
     saveCharacterData(updatedCharacter);
   }
 
+  const addTableField = (field) => {
+    const updatedField = [...character[field], {name: '', description: ''}]
+    const updatedCharacter = {...character, [field]: updatedField}
+    setCharacterData(updatedCharacter)
+  }
+
   const updateTableField = (e, field) => {
-    const cellIndex = e.id
+    const rowIndex = e.id
     const updatedField = character[field].map((element, index) => (
-      index === cellIndex ? {...element, [e.field]: e.value} : element
+      index === rowIndex ? {...element, [e.field]: e.value} : element
     ))
     const updatedCharacter = {...character, [field]: updatedField}
     setCharacterData(updatedCharacter)
+  }
+
+  const removeTableField = (rowIndex, field) => {
+    if (rowIndex != null) {
+      const updatedField = character[field].filter((element, index) => (
+        index !== rowIndex
+      ))
+      const updatedCharacter = {...character, [field]: updatedField}
+      // Using setTimeout as MUI will try to remove focus for the cell and will
+      // raise an error if it has already been deleted.
+      setTimeout(() => setCharacterData(updatedCharacter))
+    }
   }
 
   const extrasWithID = extras.map((extra, index) => {
@@ -74,7 +96,15 @@ export const FateCoreSheet = ({ rollDice, character, setCharacterData, canEdit,
   const extrasColumns = [
     {field: 'name', headerName: 'Extra', width: 240, editable: editActive},
     {field: 'description', headerName: 'Description', width: 240, flex: 1,
-      sortable: false, editable: editActive}
+      sortable: false, editable: editActive},
+    {field: 'id', headerName: 'Delete', width: 80, hide: !editActive,
+      renderCell: (params) => (
+        <IconButton aria-label='delete' color='error'
+          onClick={(e) => removeTableField(params.id ?? null, 'extras')}>
+          <RemoveIcon/>
+        </IconButton>
+      )
+    }
   ]
 
   return (
@@ -174,6 +204,11 @@ export const FateCoreSheet = ({ rollDice, character, setCharacterData, canEdit,
         disableSelectionOnClick
         onCellEditCommit={(e) => updateTableField(e, 'extras')}
       />
+      {editActive && 
+        <IconButton aria-label="add" color="success" 
+        onClick={() => addTableField('extras')}>
+          <AddIcon/>
+        </IconButton>}
     </div>
   );
 }

--- a/src/components/CharacterSheets/FateCoreSheet.js
+++ b/src/components/CharacterSheets/FateCoreSheet.js
@@ -4,7 +4,6 @@ import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { DataGrid } from '@mui/x-data-grid';
-import React, { useEffect } from 'react';
 
 const skillLadder = {
   '-2': 'Terrible',

--- a/src/utilities/CharacterSheets/FateCoreSheet.js
+++ b/src/utilities/CharacterSheets/FateCoreSheet.js
@@ -15,7 +15,7 @@ export const FateCoreSheet = {
     {type: 'Severe', description: ''}
   ],
   extras: [
-    {name: 'Example Extra', description: 'Example extra description'}
+    {id: 0, name: 'Example Extra', description: 'Example extra description'},
   ],
   aspects: [
     {name: 'High Concept',


### PR DESCRIPTION
Adds the ability to edit existing character extras, delete existing extras, and add new extras.