### PR TITLE
Fix duplication on character creation

### DIFF
--- a/src/components/CharacterManager.js
+++ b/src/components/CharacterManager.js
@@ -1,11 +1,15 @@
+import { v4 as uuidv4 } from 'uuid';
 import * as Characters from '../utilities/Characters.js';
 import './CharacterManager.css';
 
 export const CharacterManager = ({gameData={}, gm=false, openCharacters,
-  setOpenCharacters, userID}) => {
+  setOpenCharacters, updateCharacter, userID}) => {
   const createCharacter = () => {
     console.log('Creating a new character');
-    setOpenCharacters([...openCharacters, Characters.getCharacter('Fate Core')]);
+    const id = uuidv4();
+    const character = {...Characters.getCharacter('Fate Core'), _id: id}
+    updateCharacter(character)
+    setOpenCharacters([...openCharacters, character]);
   }
 
   const newCharacterTab = (e) => {

--- a/src/components/CharacterSheet.js
+++ b/src/components/CharacterSheet.js
@@ -61,9 +61,6 @@ export const CharacterSheet = ({ rollDice, character, updateCharacter, gm=false,
   let sheet;
   switch (character.format) {
     case 'Fate Core':
-      if (characterData._id == null) {
-        saveCharacter();
-      }
       sheet = <FateCoreSheet rollDice={rollDice} character={characterData} 
         gm={gm} setCharacterData={setCharacterData} editActive={editActive} canEdit={canEdit}
         saveCharacterData={saveCharacterData}/>

--- a/src/components/TabWindow.js
+++ b/src/components/TabWindow.js
@@ -49,7 +49,8 @@ export const TabWindow =  ({gameName, gameData, rollDice, users, gm,
   
       <TabPanel>
         <CharacterManager gameData={gameData} gm={gm}
-          openCharacters={openCharacters} setOpenCharacters={setOpenCharacters} userID={userID}/>
+          openCharacters={openCharacters} setOpenCharacters={setOpenCharacters} userID={userID}
+          updateCharacter={updateCharacter}/>
       </TabPanel>
   
       {openCharacters.map( (character, i) => (


### PR DESCRIPTION
Moves adding a unique ID to the character and saving it in the db to before we open the character in a tab. This appears to fix the duplication. Wasn't able to reproduce duplication on owner addition. Ignoring that until it comes up again.

Closes #50 